### PR TITLE
Fix: OSQP setup error

### DIFF
--- a/include/linalg.h
+++ b/include/linalg.h
@@ -7,6 +7,7 @@ extern "C"
 {
 #endif
 
+#include "osqp.h"
 #include "solnp.h"
 #include <math.h>
 #include <stdlib.h>
@@ -123,19 +124,19 @@ extern "C"
 		solnp_int n,
 		solnp_float *A);
 	void calculate_csc_sys(
-		solnp_int m,
-		solnp_int n,
-		solnp_float *A,
-		solnp_float *A_x,
-		solnp_int *A_i,
-		solnp_int *A_p);
+		c_int m,
+		c_int n,
+		c_float *A,
+		c_float *A_x,
+		c_int *A_i,
+		c_int *A_p);
 	void calculate_csc(
-		solnp_int m,
-		solnp_int n,
-		solnp_float *A,
-		solnp_float *A_x,
-		solnp_int *A_i,
-		solnp_int *A_p);
+		c_int m,
+		c_int n,
+		c_float *A,
+		c_float *A_x,
+		c_int *A_i,
+		c_int *A_p);
 	void max_kelement(
 		solnp_float *array,
 		solnp_int len,

--- a/source/linalg.c
+++ b/source/linalg.c
@@ -454,14 +454,14 @@ solnp_int countA(
 }
 
 void calculate_csc_sys(
-    solnp_int m,
-    solnp_int n,
-    solnp_float *A,
-    solnp_float *A_x,
-    solnp_int *A_i,
-    solnp_int *A_p)
+    c_int m,
+    c_int n,
+    c_float *A,
+    c_float *A_x,
+    c_int *A_i,
+    c_int *A_p)
 {
-      solnp_int i, j, count = 0;
+      c_int i, j, count = 0;
       A_p[0] = count;
       for (j = 0; j < n; j++)
       {
@@ -478,14 +478,14 @@ void calculate_csc_sys(
       }
 }
 void calculate_csc(
-    solnp_int m,
-    solnp_int n,
-    solnp_float *A,
-    solnp_float *A_x,
-    solnp_int *A_i,
-    solnp_int *A_p)
+    c_int m,
+    c_int n,
+    c_float *A,
+    c_float *A_x,
+    c_int *A_i,
+    c_int *A_p)
 {
-      solnp_int i, j, count = 0;
+      c_int i, j, count = 0;
       A_p[0] = count;
       for (j = 0; j < n; j++)
       {


### PR DESCRIPTION
### Problem Description
When setting the `qpsolver` to `osqp`, SOLNP+ encounters an `osqp_setup` error. This issue arises because the `c_int` (`long long`) array is being incorrectly converted to an `int` array in the `calculate_csc` and `calculate_csc_sys` functions.

### Changes Made
- Added `osqp.h` to `linalg.h` to ensure proper type definitions.
- Updated the function signatures of `calculate_csc` and `calculate_csc_sys` to handle `c_int` arrays correctly.
