### PR TITLE
feat: implement presolve functionality and adjust initial point bound

### DIFF
--- a/source/subnp_qp.c
+++ b/source/subnp_qp.c
@@ -700,6 +700,21 @@ solnp_int SUBNP(solve)(
         if (w->nic > 0.5)
         {
             memcpy(&w_sub->J->a[w_sub->J->a_row - w->nic + w_sub->npic * w_sub->J->a_row], w->ob->ic, w->nic * sizeof(solnp_float));
+            for (int i = 0; i < w->nic; i++)
+            {
+                if (w->ob->ic[i] <= w->pb->il[i])
+                {
+                    w->p[i] = w->pb->il[i] + 1e-8;
+                }
+                else if (w->ob->ic[i] >= w->pb->iu[i])
+                {
+                    w->p[i] = w->pb->iu[i] - 1e-8;
+                }
+                else
+                {
+                    w->p[i] = w->ob->ic[i];
+                }
+            }
             SOLNP(add_scaled_array)
             (&w_sub->J->a[w_sub->J->a_row - w->nic + w_sub->npic * w_sub->J->a_row], w->p, w->nic, -1.0);
         }


### PR DESCRIPTION
## Add new feature: Pre-solver for constraint problems

This PR implement a pre-solver to find a better initial point for SOLNP+ using SciPy L-BFGS-B algorithm. In addition, some changes on initiate starting point and slack variables are also made.

### Main changes

- add `presolve` function in the python interface `pysolnp.py`
- change `cal_p0` function in `pysolnp.py`
- change the initiation of slack variables in `subnp_qp.c`

### Experiment result

Tests has been conducted on a subset of CUTEst problems (with maximum variables 500 and maximum constraints 1000). Setting `tol=1e-4`,  `tol_con=1e-3`  and `max_iter=1000`, `noise=0` in SOLNP+ while keeping others default, limiting runtime for each problem be 60s, the result is as follows:

```
Filtered problems: 850
Number of problems solved by SOLNP+: 492
Number of problems solved by modified SOLNP+: 648
```